### PR TITLE
Hot fix grapling orb

### DIFF
--- a/src/main/java/gg/crystalized/essentials/CustomCoalBasedItems.java
+++ b/src/main/java/gg/crystalized/essentials/CustomCoalBasedItems.java
@@ -264,7 +264,7 @@ public class CustomCoalBasedItems implements Listener {
         Snowball sb = p.launchProjectile(Snowball.class, null);
 
         // fast & straight "hook"
-        sb.setGravity(false);
+        sb.setGravity(true);
         sb.setVelocity(p.getEyeLocation().getDirection().normalize().multiply(1.8));
 
         // tag: robust identification on hit


### PR DESCRIPTION
Enables gravity for now, and then going to be more balanced cause in crystal run it is too op