### PR TITLE
Consistant arrow damage calculator based on bow charge time. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ nb-configuration.xml
 ## OS X
 ##############################
 .DS_Store
+# The paper test server in IDEA
+run/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 plugins {
     id("java")
+    //Copied this from my test plugin, this allows to run server in IDEA
+    id("xyz.jpenilla.run-paper") version "3.0.2"
 }
 
 group = "gg.crystalized.essentials"
@@ -19,4 +21,24 @@ java {
         languageVersion.set(JavaLanguageVersion.of(25))
     }
 }
+tasks {
+    runServer {
+        //I just copied pasted that from my plugin to make run server work so that I can test it in IDEA
+        //Default comments that come with setting up the project with a plugin
+        /*
+            // Configure the Minecraft version for our task.
+            // This is the only required configuration besides applying the plugin.
+            // Your plugin's jar (or shadowJar if present) will be used automatically.
 
+         */
+        minecraftVersion("26.2")
+        jvmArgs("-Xms2G", "-Xmx2G")
+    }
+
+    processResources {
+        val props = mapOf("version" to version)
+        filesMatching("plugin.yml") {
+            expand(props)
+        }
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 #Sun Sep 22 12:18:35 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+#Changed from 8.4 to be able to support running server in idea for faster development
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/gg/crystalized/essentials/ArrowData.java
+++ b/src/main/java/gg/crystalized/essentials/ArrowData.java
@@ -13,6 +13,8 @@ import com.destroystokyo.paper.ParticleBuilder;
 
 public class ArrowData {
 
+	//I checked light strike and some bow types like multi shot are not here yet - Mish
+		//So they will just take the default crosbow damage of 8
 	enum bowType {
 		marksman,
 		ricochet,
@@ -43,12 +45,16 @@ public class ArrowData {
 	public bowType type;
 	public arrowType arrType;
 	public int timesBounced;
+	//The damage value which will be tracked for consistant damage - Mish
+	public double damage;
 
-	public ArrowData(LivingEntity shooter, bowType type, arrowType arrType, int timesBounced) {
+	public ArrowData(LivingEntity shooter, bowType type, arrowType arrType, int timesBounced, double damage) {
 		this.shooter = shooter;
 		this.type = type;
 		this.timesBounced = timesBounced;
 		this.arrType = arrType;
+		//Added damage to the constructor - Mish
+		this.damage = damage;
 	}
 
 	public static void particle_trails() {

--- a/src/main/java/gg/crystalized/essentials/CustomArrows.java
+++ b/src/main/java/gg/crystalized/essentials/CustomArrows.java
@@ -38,9 +38,10 @@ public class CustomArrows {
 		if (data.arrType == ArrowData.arrowType.spectral) {
 			SpectralArrow spec = (SpectralArrow) event.getEntity();
 			spec.setGlowingTicks(40);
+			/* Commented to make sure all arrows do the same damage on hit with the new formuala - Mish
 			if (spec.getDamage() < 0) {
 				spec.setDamage(spec.getDamage() - 2);
-			}
+			}*/
 			/*
 			ParticleBuilder builder = new ParticleBuilder(DUST);
 			builder.color(Color.YELLOW);
@@ -57,7 +58,8 @@ public class CustomArrows {
 
 
 		if (data.arrType.equals(ArrowData.arrowType.dragon)) {
-			arrow.setDamage(1);
+			//Commented to make sure all arrows do the same damage on hit with the new formuala - Mish
+			//arrow.setDamage(1);
 
 			ItemStack item = arrow.getItemStack();
 			item.setItemMeta(null);
@@ -116,7 +118,8 @@ public class CustomArrows {
 			if (i == 2) {bothUsed = true;}
 
 			arrow.setPickupStatus(DISALLOWED);
-			arrow.setDamage(2);
+			//Commented to make sure all arrows do the same damage on hit with the new formuala - Mish
+			//arrow.setDamage(2);
 
 			DamageSource.Builder builder = DamageSource.builder(EXPLOSION);
 			builder.withCausingEntity(data.shooter);
@@ -164,7 +167,8 @@ public class CustomArrows {
 		}
 		else {
 			AbstractArrow arr = (AbstractArrow) event.getEntity();
-			arr.setDamage(1.5);
+			//Commented to make sure all arrows do the same damage on hit with the new formuala - Mish
+			//arr.setDamage(1.5);
 		}
 	}
 

--- a/src/main/java/gg/crystalized/essentials/CustomBows.java
+++ b/src/main/java/gg/crystalized/essentials/CustomBows.java
@@ -7,6 +7,7 @@ import io.papermc.paper.datacomponent.item.CustomModelData;
 import io.papermc.paper.event.entity.EntityLoadCrossbowEvent;
 import org.bukkit.*;
 import org.bukkit.block.BlockFace;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -28,8 +29,69 @@ import static org.bukkit.Material.AIR;
 import static org.bukkit.Material.CROSSBOW;
 
 public class CustomBows implements Listener {
+	//If anyone except me want to experiment with damage eddit damage here - Mish
+	/*
+	* Bow min damage is 1 is the least damage it can do when having zero charge
+	* Bow max damge is when it is fully charged, now is 7hp 3.5 hearts
+	* Crossbow has no charge time so is set to 8 (4 hearts)
+	*
+	* Extra info:
+		* This is raw damage, things like arrmor and resistance will reduce it
+		* So it functions as it should
+	* */
+	private static final double BOW_MIN_DAMAGE = 1.0;
+	private static final double BOW_MAX_DAMAGE = 7.0;
+	private static final double CROSSBOW_DAMAGE = 8.0;
 	public static HashMap<Projectile, ArrowData> arrows = new HashMap<>();
 
+	//This method is used to calculate arrow's base damage, takes in the weapon and it's charge force
+	private double calculateArrowDamage(ItemStack weapon, float weaponChargedForce){
+		switch (weapon.getType()) {
+			case BOW -> {
+				//Clamps bow charge between 0 and 1 cleanly
+				/*Simple explanations of clamp incase you never saw it - by Mish
+					*It takes in the weapon charge value and clamps it between 0.0 and 1.0
+					* Meaning that if for some reason it is higher than 1.0 it will return 1.0
+					* Or if for some reason is is less than 0.0 it wil return 0.0
+					* If it is between those values it leaves the value the same
+				* This is just more of a safety check as charge should be between 0 and 1
+					* */
+				double charge = Math.clamp(weaponChargedForce, 0.0f, 1.0f);
+				//This is a basic lerp formula:  min + (max - min) * t
+				//It calculates the value between minimum and maximum.
+				//In this case it will output the bows damage between the charges
+					//Example of zero bow charge: 1 + (7 - 1) * 0 = 1.0
+					//Example of half bow charge: 1 + (7 - 1) * 0.5 = 4.0
+					//Example of full bow charge: 1 + (7 - 1) * 1 = 7.0
+					//You can learn more here about lerp and this formula
+						//https://gamedev.net/tutorials/programming/general-and-gameplay-programming/linear-interpolation-explained-r5892
+				double baseDamage = BOW_MIN_DAMAGE + (BOW_MAX_DAMAGE - BOW_MIN_DAMAGE) * charge;
+
+				//This is incase any bows in the future have power enchatment, so that it still works
+				int powerLevel = weapon.getEnchantmentLevel(Enchantment.POWER);
+				//The default multiplier is 1
+				double powerMultiplier = 1.0;
+				//TODO: If power is added and is too overpowered try another formula (Like 1 extra damge per power)
+				if (powerLevel > 0) {
+					//Vanila formula: Power increase arrow damage by 25% × (level + 1)
+					//https://minecraft.fandom.com/wiki/Power
+					powerMultiplier = powerMultiplier + ( 0.25 * (powerLevel + 1));
+				}
+				//The base damage is multiplied to power multiplier (If no power is just 1)
+				return baseDamage * powerMultiplier;
+			}
+
+			//Crossbow has no charge force like the bow, so damage will allways be the same
+			case CROSSBOW -> {
+				return CROSSBOW_DAMAGE;
+			}
+			//If not bow or cross bow sets damage to zero
+			default -> {
+				return 0.0;
+			}
+		}
+
+	}
 	@EventHandler(priority = EventPriority.HIGH)
 	public void onBowShot(EntityShootBowEvent event) {
 		if (event.isCancelled()) {
@@ -60,7 +122,10 @@ public class CustomBows implements Listener {
 			}
 		}
 
-		ArrowData ard = new ArrowData(event.getEntity(), type, arrType, 0);
+		//TODO: add damage - DONE
+		//Added damge here
+		double damage = calculateArrowDamage(bow_item, event.getForce());
+		ArrowData ard = new ArrowData(event.getEntity(), type, arrType, 0, damage);
 		arrows.put((Projectile) event.getProjectile(), ard);
 	}
 
@@ -74,16 +139,27 @@ public class CustomBows implements Listener {
 		if (data == null) {
 			return;
 		}
+		//Calculates the default damage first - Mish.
+		//Can be over written or added on by bow types below
+		e.setDamage(data.damage);
+
+
 
 		// deal extra damge for marksman
+		//Marksman adjusted by Mish
 		switch (data.type) {
 			case marksman -> {
 				Location shooterLoc = data.shooter.getLocation();
 				Location hitLoc = e.getEntity().getLocation();
-				double distance = Math.floor(shooterLoc.distance(hitLoc) / 10);
-				((LivingEntity) e.getEntity()).damage(distance);
+				double distance = Math.floor(shooterLoc.distance(hitLoc) / 10.0);
+				//Was setting extra damage on top of default damage
+					//((LivingEntity) e.getEntity()).damage(distance);
+				//Now it sets the new default bow damage + distance
+				e.setDamage(e.getDamage() + distance);
 			}
 			case charged -> {
+				//Charged cross bow cancels the event, so it ignores both new and default minecraft damage
+				//So it sets it's own damage
 				e.setCancelled(true);
 				Location eloc = e.getEntity().getLocation();
 				Location arrloc = e.getDamager().getLocation();
@@ -100,7 +176,16 @@ public class CustomBows implements Listener {
 				Location eloc = e.getEntity().getLocation();
 				Location arrloc = e.getDamager().getLocation();
 				if (arrloc.getY() - eloc.getY() >= 1.7 && arrloc.getY() - eloc.getY() <= 2) {
-					((LivingEntity) e.getEntity()).damage(e.getDamage() * 2);
+					/*Why is this so op, it adds extra damage on top, so that is like 8 default
+					* + 16 extra damage. So total is 24 damage. I am nerfing to be 16
+					* Cause no way it is was intentional - Mish
+					* */
+					//OLD:
+						//((LivingEntity) e.getEntity()).damage(e.getDamage() * 2);
+
+					/*Now this gets the cross bow default damage and multiplies it by 2.
+					* */
+					e.setDamage(e.getDamage() * 2);
                     e.getEntity().setVelocity(e.getEntity().getVelocity().multiply(1.2));
 				}
 			}
@@ -113,6 +198,11 @@ public class CustomBows implements Listener {
 				double z = p.getZ() - en.getZ();
 				e.getEntity().setVelocity(new Vector(x, y, z).normalize().multiply(1.9));
 			}
+		}
+
+		if(!e.isCancelled()){
+			//Check for marksman distance
+			System.out.println(e.getDamage());
 		}
 	}
 
@@ -157,7 +247,9 @@ public class CustomBows implements Listener {
 
 			data.timesBounced++;
 			Arrow arrow = event.getEntity().getWorld().spawnArrow(loc, velocity, (float) velocity.length(), 0);
-			arrow.setDamage(arrow.getDamage() + (0.2 * (float) data.timesBounced));
+			//Replaced with the new data.damage calculator so, 0.2 is not lost
+				//arrow.setDamage(arrow.getDamage() + (0.2 * (float) data.timesBounced));
+			data.damage += 0.2  * (float) data.timesBounced;
 			arrow.setPickupStatus(AbstractArrow.PickupStatus.ALLOWED);
 			arrow.setShooter(event.getEntity().getShooter());
 			arrows.remove(event.getEntity());
@@ -166,7 +258,9 @@ public class CustomBows implements Listener {
 			return;
 		} else if (data.type == ArrowData.bowType.normalCrossbow) {
 			// I have no idea what I just wrote but I hope this works
-			((AbstractArrow) event.getEntity()).setDamage(((AbstractArrow) event.getEntity()).getDamage() - 1);
+			//Commented out to ensure that new calculator calculates damage - Mish
+				//((AbstractArrow) event.getEntity()).setDamage(((AbstractArrow) event.getEntity()).getDamage() - 1);
+			//It is set to 8 by Default so no need to add anything here - Mish
 		}
 		CustomArrows.onArrowHit(event);
 	}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,5 @@
 name: Crystalized_Essentials
 version: 0.0.1
 main: gg.crystalized.essentials.crystalized_essentials
-api-version: '1.21.3'
+#Updated to the latest API
+api-version: '26.2'

--- a/target/classes/plugin.yml
+++ b/target/classes/plugin.yml
@@ -1,4 +1,5 @@
 name: crystalized-essentials
 version: '1.0-SNAPSHOT'
 main: gg.crystalized.crystalizedessentials.Crystalized_essentials
-api-version: '1.21'
+#Updated To The Latest API
+api-version: '26.2'


### PR DESCRIPTION
Successfully implemented the arrow damage calculator. Tested it thoroughly, with different bow types and crossbows. Made arrow types consistent and kept the damage boost per bounce for the Rechoshet bow

Initial damage values
Bow min: 1.0
Bow max: 7.0

Crossbow: 8.0

Marksman still works and other weapon types. Nefed op crosbow that has been removed before.

Comments explain how math works

Also changed Gradle version to be able to run the server in Intelija. And Api to 26.2