### PR TITLE
Bug Hot Fixes: Exploding arrow damage, and Rechacet Bow

### DIFF
--- a/src/main/java/gg/crystalized/essentials/CustomArrows.java
+++ b/src/main/java/gg/crystalized/essentials/CustomArrows.java
@@ -13,7 +13,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
-import java.util.Collection;
+import java.util.*;
 
 import static org.bukkit.Color.PURPLE;
 import static org.bukkit.Particle.DUST;
@@ -23,6 +23,15 @@ import static org.bukkit.entity.AbstractArrow.PickupStatus.DISALLOWED;
 import static org.bukkit.entity.EntityType.AREA_EFFECT_CLOUD;
 
 public class CustomArrows {
+
+	//Originaly used set to track the UUID of player's who got hit directly by explosive arrow
+	//Then I remembered that a person can get shot by 2 explosive arrows, hence removing early and exposive to damage,
+	// so had to migrate to Map
+		//private static final Set<UUID> STORES_DIRECT_EXPLOSIVE_HITS = new HashSet<>();
+
+	//This is a new implementation using map with UUID and Integer, storing players UUID and amount of exploding arrows in player
+	//Removes straight after the explosions happen
+	private static final Map<UUID, Integer> PLAYERS_HIT_BY_EXPLOSIVE_ARROW = new HashMap<>();
 
 	public static void onArrowHit(ProjectileHitEvent event) {
 		if (event.isCancelled()) {
@@ -127,12 +136,60 @@ public class CustomArrows {
 			builder.withDamageLocation(arrow.getLocation());
 			DamageSource source = builder.build();
 
-			Entity hit_player = event.getHitEntity();
+
+			Entity hitPlayer = event.getHitEntity();
+			//Checks specificly if it is a LivingEntity instanse that has been hit
+			//Mostly for players but in the future if there are games with mobs I made it work with LivingEntities last minute
+			if (hitPlayer instanceof LivingEntity player) {
+				//Get the players unique UUID
+				UUID hitPlayerUUID = player.getUniqueId();
+				long protectionLastsTicks;
+				if (bothUsed) {
+					//Only when explosives bow and arrow used together
+					protectionLastsTicks= 18L;
+				} else {
+					//Normal just explosive arrow, or explosive bow
+					protectionLastsTicks = 2L;
+				}
+				//Ads the player UUID to the map, with the value 1. If UUID already exist it sums them together
+				//So that is why the method is called merge as it merges them together
+				//Integer::sum: sums up the new and old value
+				//So in this case, it will be on first hit (0+1) = 1, on second hit (1+1) = 2, on third (2+1) = 3
+				PLAYERS_HIT_BY_EXPLOSIVE_ARROW.merge(hitPlayerUUID, 1, Integer::sum);
+				//Sumons the explosion - same as before
+				exploArrowExplosion(arrow_loc, source, bothUsed);
+				//Scheduling the task to be after protection ticks expired
+				Bukkit.getScheduler().runTaskLater(
+						crystalized_essentials.getInstance(),
+						//If UUID exists in the map then it computes this
+						() -> PLAYERS_HIT_BY_EXPLOSIVE_ARROW.computeIfPresent(
+								//pases om the player's UUID
+								hitPlayerUUID,
+								(uuid, arrowsHitThePlayer) -> {
+									//If smaller or equal to 1 than player is removed from the map
+									if (arrowsHitThePlayer <= 1) {
+										return null;
+									}
+									//If is bigger than 1 than removes 1
+									//It should run again because the second arrow has hit and scheduled this task
+									return arrowsHitThePlayer - 1;
+								}
+						),
+						//The delay is depeneded if there is a double explosion or not
+						protectionLastsTicks
+				);
+				//Arrow removed same as before
+
+				arrow.remove();
+				return;
+			}
+			/*
+			Older implementation
 			if (hit_player != null) {
 				exploArrowExplosion(arrow_loc, source, bothUsed);
 				arrow.remove();
 				return;
-			}
+			}*/
 			arrow.setGlowing(true);
 
 			boolean bothused1 = bothUsed; //This is dumb
@@ -172,6 +229,7 @@ public class CustomArrows {
 		}
 	}
 
+
 	private static void exploArrowExplosion(Location explo_loc, DamageSource source, Boolean explosiveBowUsed) {
 		Collection<LivingEntity> nearby = explo_loc.getNearbyLivingEntities(2);
 		Collection<LivingEntity> notSoNearby = explo_loc.getNearbyLivingEntities(4);
@@ -203,5 +261,10 @@ public class CustomArrows {
 		builder.count(300);
 		builder.location(explo_loc);
 		builder.spawn();
+	}
+	//This is a method that returns true if the uuid of the player is contained in the map
+	//If so then the protection against the explosion damage is activated in CustomBows
+	public static boolean isDirectExplosiveHit(UUID uuid) {
+		return PLAYERS_HIT_BY_EXPLOSIVE_ARROW.containsKey(uuid);
 	}
 }

--- a/src/main/java/gg/crystalized/essentials/CustomBows.java
+++ b/src/main/java/gg/crystalized/essentials/CustomBows.java
@@ -200,6 +200,7 @@ public class CustomBows implements Listener {
 			}
 		}
 
+		//Will remain visible for now, for testing with people later. - Mish
 		if(!e.isCancelled()){
 			//Check for marksman distance
 			System.out.println(e.getDamage());

--- a/src/main/java/gg/crystalized/essentials/CustomBows.java
+++ b/src/main/java/gg/crystalized/essentials/CustomBows.java
@@ -13,6 +13,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.player.PlayerPickupArrowEvent;
@@ -42,6 +43,9 @@ public class CustomBows implements Listener {
 	private static final double BOW_MIN_DAMAGE = 1.0;
 	private static final double BOW_MAX_DAMAGE = 7.0;
 	private static final double CROSSBOW_DAMAGE = 8.0;
+	//Change the extra damage that the player gets here from the direct hit exploision
+	//I had to change it as otherwise player wasn't getting any explosion damage - Mish
+	private static final double EXPLOSION_DAMAGE_BONUCE = 3.5;
 	public static HashMap<Projectile, ArrowData> arrows = new HashMap<>();
 
 	//This method is used to calculate arrow's base damage, takes in the weapon and it's charge force
@@ -141,7 +145,29 @@ public class CustomBows implements Listener {
 		}
 		//Calculates the default damage first - Mish.
 		//Can be over written or added on by bow types below
+
 		e.setDamage(data.damage);
+
+		//Don't know why but the player feels like he doesn't care about explosions anymore
+		//Getting no damage from it, I tried everything but this seems like the best robust fix
+		//So I made this kinda fix that makes the direct explosive damage consistant
+		//Added extra UUID protection, incase on servers people with diffrent ping might experince a lot more damage
+		//Or for any other reason the damage just starts applying.
+			//In custom arrows
+		boolean isExplosiveArrow = data.arrType == ArrowData.arrowType.explosive;
+		boolean isExplosiveBow = data.type == ArrowData.bowType.explosive;
+
+		if (isExplosiveArrow || isExplosiveBow) {
+
+			double explosiveDamageBonus = EXPLOSION_DAMAGE_BONUCE;
+			//Not sure if this bow is in the game but the explosion will be slightly stronger
+			if (isExplosiveArrow && isExplosiveBow) {
+				explosiveDamageBonus = explosiveDamageBonus + 1.5;
+			}
+
+			e.setDamage(e.getDamage() + explosiveDamageBonus);
+		}
+
 
 
 
@@ -206,6 +232,23 @@ public class CustomBows implements Listener {
 			System.out.println(e.getDamage());
 		}
 	}
+	//This makes sure that the explosion damage is zero for the player that got directly hit
+	//As the direct hit damage is set manualy
+	@EventHandler(priority = EventPriority.HIGH)
+	public void onDirectExplosionDamage(EntityDamageByEntityEvent event) {
+		//If it is not due to the explosion than nothing happens
+		if (event.getCause() != EntityDamageEvent.DamageCause.ENTITY_EXPLOSION) {
+			return;
+		}
+		//If it is not contained in the map than nothing happens
+		if (!CustomArrows.isDirectExplosiveHit(event.getEntity().getUniqueId())) {
+			return;
+		}
+		//Sets the explosion damage to zero to prevent potential double damage from explosion
+		//It works without it on my end as damage from the explosion is not registering on direct hit
+		//But here it makes sure that for everyone the direct explosion hit would be consistant, accross servers and pings.
+		event.setDamage(0.0);
+	}
 
 	@EventHandler(priority = EventPriority.HIGH)
 	public void onArrowHit(ProjectileHitEvent event) {
@@ -225,6 +268,8 @@ public class CustomBows implements Listener {
 				return;
 			}
 			if (event.getHitEntity() != null && event.getHitEntity() instanceof Player) {
+				//Makes sure that arrow custom effect still happens when rechochet bow hits - Mish
+				CustomArrows.onArrowHit(event);
 				return;
 			}
 			Location loc = event.getEntity().getLocation();
@@ -247,19 +292,33 @@ public class CustomBows implements Listener {
 			}
 
 			data.timesBounced++;
-			Arrow arrow = event.getEntity().getWorld().spawnArrow(loc, velocity, (float) velocity.length(), 0);
+			//Copying the item stack so that the arrows could stack in player inventory after pick up
+			ItemStack theOriginalArrowItem = ar.getItemStack().clone();
+			//FIXED: Fix the bug with spectular arrow causing an exception with rechashet bow
+			//Using the abstract arrow
+			AbstractArrow newArrow;
+			if (event.getEntity() instanceof SpectralArrow) {
+				//If it a spectral arrow than the abstract arrow is set to spectral arrow, everythin else is idnetical as before
+				//Old arrow
+					//Arrow arrow = event.getEntity().getWorld().spawnArrow(loc, velocity, (float) velocity.length(), 0);
+				newArrow = event.getEntity().getWorld().spawnArrow(loc, velocity, (float) velocity.length(), 0, SpectralArrow.class);
+			} else {
+				newArrow = event.getEntity().getWorld().spawnArrow(loc, velocity, (float) velocity.length(), 0, Arrow.class);
+			}
+			//Sets the new arrow item stack to the original arrow item stack, so that it can stack in player inventory
+			newArrow.setItemStack(theOriginalArrowItem);
 			//Replaced with the new data.damage calculator so, 0.2 is not lost
 				//arrow.setDamage(arrow.getDamage() + (0.2 * (float) data.timesBounced));
 			data.damage += 0.2  * (float) data.timesBounced;
-			arrow.setPickupStatus(AbstractArrow.PickupStatus.ALLOWED);
-			arrow.setShooter(event.getEntity().getShooter());
+			newArrow.setPickupStatus(AbstractArrow.PickupStatus.ALLOWED);
+			newArrow.setShooter(event.getEntity().getShooter());
 			arrows.remove(event.getEntity());
 			event.getEntity().remove();
-			arrows.put(arrow, data);
+			arrows.put(newArrow, data);
 			return;
 		} else if (data.type == ArrowData.bowType.normalCrossbow) {
-			// I have no idea what I just wrote but I hope this works
 			//Commented out to ensure that new calculator calculates damage - Mish
+				// I have no idea what I just wrote but I hope this works - Someone else
 				//((AbstractArrow) event.getEntity()).setDamage(((AbstractArrow) event.getEntity()).getDamage() - 1);
 			//It is set to 8 by Default so no need to add anything here - Mish
 		}


### PR DESCRIPTION
The extra damage from the explosion stopped working when being hit by the arrow directly. So I made a workaround where the explosion damage is applied to the target. 

In the case that on other servers or rarely damage might apply somehow anyway. I added a safety check using uniq player's id, and stored it in a Map. So now, for a brief period, the player won't be damaged by explosions after being directly hit by an explosion arrow. 

Making the explosion arrow damage consistent when hit directly. 

The rechachete bow has been fixed as well, so now it behaves as expected. And explode arrow explode when using rechacte bow when they shoot the player. So it behaves perfectly.